### PR TITLE
feat: add ChartVersion enum and rename Chart to ChartV1

### DIFF
--- a/src/models/Statistic.ts
+++ b/src/models/Statistic.ts
@@ -69,13 +69,20 @@ export interface ChartConfig {
   dataPoints: DataPointRequest[];
 }
 
-export interface Chart {
+export enum ChartVersion {
+  V1 = 1,
+}
+
+export interface ChartV1 {
+  version: ChartVersion.V1;
   name: string;
   config: ChartConfig;
   userId: string;
   createdAt: Date;
   updatedAt: Date;
 }
+
+export type Chart = ChartV1;
 
 export interface ChartRequest {
   config: ChartConfig;


### PR DESCRIPTION
Add `ChartVersion` enum with `V1 = 1`, rename `Chart` interface to `ChartV1` with a `version` field, and export `Chart` as a type alias for `ChartV1` (union-ready for future versions).

Closes #14

Generated with [Claude Code](https://claude.ai/code)