### PR TITLE
feat: add ChartVersion enum and versioning on ChartConfig

### DIFF
--- a/src/models/Statistic.ts
+++ b/src/models/Statistic.ts
@@ -63,11 +63,18 @@ export type SegmentedDataPoint = {
   value: SegmentedDataPointValue;
 };
 
-export interface ChartConfig {
+export enum ChartVersion {
+  V1 = 1,
+}
+
+export interface ChartConfigV1 {
+  version: ChartVersion.V1;
   dataWindow: DataWindow;
   segmentation: Segmentation;
   dataPoints: DataPointRequest[];
 }
+
+export type ChartConfig = ChartConfigV1;
 
 export interface Chart {
   name: string;
@@ -84,6 +91,7 @@ export interface ChartRequest {
 }
 
 export const exampleChartRequest: ChartConfig = {
+  version: ChartVersion.V1,
   dataWindow: {
     type: DataWindowType.CUSTOM,
     start: new Date("2024-01-01T00:00:00Z"),


### PR DESCRIPTION
Add `ChartVersion` enum with `V1 = 1`, rename `ChartConfig` to `ChartConfigV1` with a `version` field, and export `ChartConfig` as a type alias for `ChartConfigV1` (union-ready for future versions). `Chart` interface is unchanged.

Closes #14

Generated with [Claude Code](https://claude.ai/code)