### PR TITLE
feat: add Theme enum and theme property to Workspace interface

### DIFF
--- a/src/models/Workspace.ts
+++ b/src/models/Workspace.ts
@@ -1,3 +1,9 @@
+export enum Theme {
+  LIGHT = "light",
+  DARK = "dark",
+  SYSTEM = "system",
+}
+
 export interface Workspace {
   id: string;
   name: string;
@@ -7,4 +13,5 @@ export interface Workspace {
   color: string;
   showEverything: boolean;
   listConfigs: string[];
+  theme: Theme;
 }


### PR DESCRIPTION
Adds a `Theme` enum (`light`, `dark`, `system`) and `theme: Theme` property to the `Workspace` interface.

Closes #17

Generated with [Claude Code](https://claude.ai/code)