### PR TITLE
Add timezone setting (user context, number type)

### DIFF
--- a/src/models/Setting.ts
+++ b/src/models/Setting.ts
@@ -34,6 +34,7 @@ export enum SettingName {
   AUTO_PUBLISH = "autoPublish",
   ENABLE_2FA = "enable2FA",
   DEFAULT_WORKSPACE = "defaultWorkspace",
+  TIMEZONE = "timezone",
 }
 
 export enum PaginationType {
@@ -163,6 +164,11 @@ export interface DefaultWorkspaceSettingConfig extends TextSettingConfig {
   group: SettingGroup.MISC;
 }
 
+export interface TimezoneSettingConfig extends NumberSettingConfig {
+  name: SettingName.TIMEZONE;
+  group: SettingGroup.MISC;
+}
+
 export type SettingsConfig = {
   [SettingName.PAGINATION_TYPE]: PaginationTypeSettingConfig;
   [SettingName.PAGINATION_PAGE_SIZE]: PaginationPageSizeSettingConfig;
@@ -175,6 +181,7 @@ export type SettingsConfig = {
   [SettingName.AUTO_PUBLISH]: AutoPublishSettingConfig;
   [SettingName.ENABLE_2FA]: Enable2FASettingConfig;
   [SettingName.DEFAULT_WORKSPACE]: DefaultWorkspaceSettingConfig;
+  [SettingName.TIMEZONE]: TimezoneSettingConfig;
 };
 
 export type SettingConfig = SettingsConfig[keyof SettingsConfig];
@@ -277,6 +284,13 @@ export const settingsConfig: SettingsConfig = {
     control: { type: ControlType.TEXT },
     group: SettingGroup.MISC,
     defaultValue: "",
+    context: [SettingContextType.USER],
+  },
+  [SettingName.TIMEZONE]: {
+    name: SettingName.TIMEZONE,
+    control: { type: ControlType.NUMBER },
+    group: SettingGroup.MISC,
+    defaultValue: 0,
     context: [SettingContextType.USER],
   },
 };


### PR DESCRIPTION
Adds a new `timezone` setting, available only in the user context, typed as a number.

- Added `SettingName.TIMEZONE`
- Added `TimezoneSettingConfig` interface extending `NumberSettingConfig`, grouped under `SettingGroup.MISC`
- Registered in `SettingsConfig` and `settingsConfig` with `context: [SettingContextType.USER]` and `defaultValue: 0`

Closes #19

Generated with [Claude Code](https://claude.ai/code)