### PR TITLE
feat: add propertySum fact type

### DIFF
--- a/src/models/Fact.ts
+++ b/src/models/Fact.ts
@@ -5,6 +5,7 @@ export enum FactOperation {
   UNIQUE_TAG_COUNT = "uniqueTagCount",
   MEDAL_COUNT = "medalCount",
   ANALYSIS_CLASSIFICATION = "analysisClassification",
+  PROPERTY_SUM = "propertySum",
 }
 
 export enum AnalysisClassificationType {
@@ -60,8 +61,15 @@ export type AnalysisClassificationFactContext = {
   analysisType: AnalysisClassificationType;
 };
 
+export type PropertySumFactContext = {
+  operation: FactOperation.PROPERTY_SUM;
+  filter: ListFilter;
+  propertyConfigId: number;
+};
+
 export type FactContext =
   | EntityCountFactContext
   | UniqueTagCountFactContext
   | MedalCountFactContext
-  | AnalysisClassificationFactContext;
+  | AnalysisClassificationFactContext
+  | PropertySumFactContext;


### PR DESCRIPTION
Adds a new `propertySum` fact type to `src/models/Fact.ts`.

Includes:
- `PROPERTY_SUM` enum value in `FactOperation`
- `PropertySumFactContext` type with `operation`, `filter: ListFilter`, and `propertyConfigId: number` fields
- `PropertySumFactContext` added to the `FactContext` discriminated union

Closes #21

Generated with [Claude Code](https://claude.ai/code)