### PR TITLE
feat: add matchUnset to FilterProperty

### DIFF
--- a/src/models/List.ts
+++ b/src/models/List.ts
@@ -48,6 +48,7 @@ export interface FilterProperty {
   propertyId: number;
   value: PropertyDataValue;
   operation: TextType;
+  matchUnset?: boolean;
 }
 export interface ListFilter {
   userIds?: string[];


### PR DESCRIPTION
Add optional boolean property `matchUnset` to the `FilterProperty` interface in `src/models/List.ts`.

Closes #23

Generated with [Claude Code](https://claude.ai/code)