### PR TITLE
feat: add Fact and FactResult interfaces

### DIFF
--- a/src/models/Fact.ts
+++ b/src/models/Fact.ts
@@ -76,6 +76,20 @@ export type FactContext =
   | AnalysisClassificationFactContext
   | PropertySumFactContext;
 
+export interface Fact {
+  id: number;
+  name: string;
+  userId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  context: FactContext;
+}
+
+export interface FactResult {
+  factId: number;
+  value: string | number;
+}
+
 export interface FactRequest {
   alias: string;
   context: FactContext;


### PR DESCRIPTION
Adds `Fact` and `FactResult` interfaces to `src/models/Fact.ts`, modeled after the existing `Streak` and `StreakResult` interfaces.

Closes #26

Generated with [Claude Code](https://claude.ai/code)