### PR TITLE
Add charts property to Workspace interface

### DIFF
--- a/src/models/Workspace.ts
+++ b/src/models/Workspace.ts
@@ -10,4 +10,5 @@ export interface Workspace {
   theme: string;
   facts: number[];
   streaks: number[];
+  charts: number[];
 }


### PR DESCRIPTION
Adds a new `charts: number[]` property to the `Workspace` interface, following the existing pattern used by `facts` and `streaks`.

Closes #28.

Generated with [Claude Code](https://claude.ai/code)