### PR TITLE
Add sugarIntake and calorieIntake analysis classification types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,4 +58,8 @@ Static JSON fixtures (`entities.json`, `items.json`, `properties.json`) exported
 
 ## Versioning
 
-See [docs/versioning.md](docs/versioning.md) for further details on how to create a new version.
+See [doc/versioning.md](doc/versioning.md) for further details on how to create a new version.
+
+## Analysis classifications
+
+See [doc/analysis-classifications.md](doc/analysis-classifications.md) for the process of adding a new analysis classification type.

--- a/doc/analysis-classifications.md
+++ b/doc/analysis-classifications.md
@@ -1,0 +1,27 @@
+## Analysis Classifications
+
+This document outlines the process for adding a new analysis classification type. It is primarily intended to be consumed by Claude for understanding the expected process when extending analysis classifications locally.
+
+### Process
+
+Adding a new analysis classification type consists of two changes that must stay in sync: the enum that identifies the type, and the prompt configuration that describes it to the classifier.
+
+#### Step 1
+
+Add the new type to the `AnalysisClassificationType` enum in `src/models/Fact.ts`. The string value is the key used to look up its configuration.
+
+#### Step 2
+
+Add a corresponding entry to `src/models/data/analysisConfig.json`, keyed by that same string value. Each entry has a `promptConfig` object with:
+
+- `description` — a short description of what is being classified.
+- `scale` — describes the range and meaning of the value returned by the classifier (e.g. a `0.0`–`1.0` scale, or an integer count).
+- `notes` — an array of any additional instructions or edge cases the classifier should consider. Use `[]` if there are none.
+
+#### Step 3
+
+Run `npm run build` to verify the change compiles cleanly.
+
+#### Step 4
+
+Follow the [versioning process](versioning.md) to publish the change. `analysisConfig.json` is uploaded to Azure Blob Storage by the `Publish Analysis Config` GitHub workflow whenever a new tag is pushed.

--- a/src/models/Fact.ts
+++ b/src/models/Fact.ts
@@ -15,6 +15,8 @@ export enum AnalysisClassificationType {
   MORNING_FASTING = "morningFasting",
   AFTERNOON_SNACKING = "afternoonSnacking",
   CAFFEINE_INTAKE = "caffeineIntake",
+  SUGAR_INTAKE = "sugarIntake",
+  CALORIE_INTAKE = "calorieIntake",
 }
 
 export interface AnalysisClassificationConfig {

--- a/src/models/data/analysisConfig.json
+++ b/src/models/data/analysisConfig.json
@@ -27,5 +27,25 @@
         "Return 0 if none are found, or null if there is genuinely not enough data to determine."
       ]
     }
+  },
+  "sugarIntake": {
+    "promptConfig": {
+      "description": "the intensity of added sugar consumption",
+      "scale": "0.0 = no added sugar consumed, 1.0 = very high added sugar consumption (frequent sugary foods or drinks)",
+      "notes": [
+        "Consider both food and drink sources of added sugar.",
+        "Natural sugars in whole fruits should weigh less heavily than refined or added sugars."
+      ]
+    }
+  },
+  "calorieIntake": {
+    "promptConfig": {
+      "description": "estimated total caloric intake",
+      "scale": "integer — estimated total calories consumed within the time window, based on the described food and drink items",
+      "notes": [
+        "Estimate calories using typical caloric values for the foods and drinks described.",
+        "Return null if there is genuinely not enough information to make a reasonable estimate."
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `sugarIntake` and `calorieIntake` to the `AnalysisClassificationType` enum
- Adds corresponding entries to `analysisConfig.json`
- Adds `doc/analysis-classifications.md` documenting the process for adding new analysis classification types
- Updates `CLAUDE.md` with a link to the new doc, and fixes a pre-existing broken link to the versioning doc

Closes #31

Generated with [Claude Code](https://claude.ai/code)