### PR TITLE
Add StreakAlertConfig interface for streak reminders

### DIFF
--- a/src/models/Fact.ts
+++ b/src/models/Fact.ts
@@ -115,6 +115,13 @@ export interface StreakContext {
   innerValue: string | number | boolean;
 }
 
+export interface StreakAlertConfig {
+  id: number;
+  streakId: number;
+  userId: string;
+  noticeTime: number;
+}
+
 export interface Streak {
   id: number;
   name: string;
@@ -122,6 +129,7 @@ export interface Streak {
   createdAt: Date;
   updatedAt: Date;
   context: StreakContext;
+  alerts: StreakAlertConfig[];
 }
 
 export interface StreakResult {


### PR DESCRIPTION
## Summary
- Adds a new `StreakAlertConfig` interface (`id`, `streakId`, `userId`, `noticeTime`) to support streak reminder notifications
- Updates the `Streak` interface to include `alerts: StreakAlertConfig[]`

Closes #30

## Note
`npm run build` was not run in the automated session due to tool permission restrictions; please run the build and version bump locally per doc/versioning.md before publishing.

Generated with [Claude Code](https://claude.ai/code)