### PR TITLE
Add createdAt and updatedAt to StreakAlertConfig

### DIFF
--- a/src/models/Fact.ts
+++ b/src/models/Fact.ts
@@ -120,6 +120,8 @@ export interface StreakAlertConfig {
   streakId: number;
   userId: string;
   noticeTime: number;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface Streak {


### PR DESCRIPTION
Adds the missing `createdAt` and `updatedAt` `Date` fields to `StreakAlertConfig` in `src/models/Fact.ts`, matching the pattern used by the sibling `Fact` and `Streak` interfaces.

Closes #35

Generated with [Claude Code](https://claude.ai/code)