### PR TITLE
Add orderProperties bulk operation

### DIFF
--- a/src/models/Operation.ts
+++ b/src/models/Operation.ts
@@ -8,6 +8,7 @@ export enum OperationType {
   REPLACE_PROPERTIES = "replaceProperties",
   ADD_PROPERTIES = "addProperties",
   REMOVE_PROPERTIES = "removeProperties",
+  ORDER_PROPERTIES = "orderProperties",
 }
 
 export interface DeleteOperation {
@@ -44,6 +45,16 @@ export interface RemovePropertiesOperation {
   properties: EntityProperty[];
 }
 
+export interface PropertyOrder {
+  propertyConfigId: number;
+  order: number;
+}
+
+export interface OrderPropertiesOperation {
+  type: OperationType.ORDER_PROPERTIES;
+  propertyOrder: PropertyOrder[];
+}
+
 export type Operation =
   | DeleteOperation
   | ReplaceTagsOperation
@@ -51,7 +62,8 @@ export type Operation =
   | RemoveTagsOperation
   | ReplacePropertiesOperation
   | AddPropertiesOperation
-  | RemovePropertiesOperation;
+  | RemovePropertiesOperation
+  | OrderPropertiesOperation;
 
 export interface BulkOperation {
   operation: Operation;


### PR DESCRIPTION
Adds a new `orderProperties` bulk operation to `src/models/Operation.ts`:

- `OperationType.ORDER_PROPERTIES` = "orderProperties"
- New `PropertyOrder` interface: `{ propertyConfigId: number; order: number }`
- New `OrderPropertiesOperation` interface carrying a `propertyOrder: PropertyOrder[]` list
- Extended the `Operation` union to include it

Closes #10.

Generated with [Claude Code](https://claude.ai/code)